### PR TITLE
ci: include basic automated testing

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,12 @@
+# Workflow for pull requests to master branch
+
+name: Pull Request workflow
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint-and-test:
+    uses: ./.github/workflows/test-and-lint.yaml

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,10 +15,14 @@ on:
       - master
 
 jobs:
+  test-and-lint:
+    uses: ./.github/workflows/test-and-lint.yaml
+
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
     concurrency: push
+    needs: [test-and-lint]
     if: github.repository == 'swvanbuuren/mlpyqtgraph'
     environment:
       name: pypi

--- a/.github/workflows/test-and-lint.yaml
+++ b/.github/workflows/test-and-lint.yaml
@@ -20,6 +20,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set environment variables
+      run: |
+        echo "UV_SYSTEM_PYTHON=true" >> $GITHUB_ENV
+
     # used docker image already has uv    
     # - name: Install uv
     #   uses: astral-sh/setup-uv@v3
@@ -32,9 +36,6 @@ jobs:
     - name: Install the project
       run: |
         uv sync
-        # get the directory to the site packages in .venv
-        PYTHON_SITE_PACKAGES=$(find .venv/lib -type d -name "python3.*" -exec echo {}/site-packages \;)
-        export LD_LIBRARY_PATH="${PYTHON_SITE_PACKAGES}:$LD_LIBRARY_PATH"
 
     # Commented out because linter rules violations are not fixed yet
     # - name: Lint with ruff

--- a/.github/workflows/test-and-lint.yaml
+++ b/.github/workflows/test-and-lint.yaml
@@ -20,8 +20,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v3
+    # used docker image already has uv    
+    # - name: Install uv
+    #   uses: astral-sh/setup-uv@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -31,6 +32,9 @@ jobs:
     - name: Install the project
       run: |
         uv sync
+        # get the directory to the site packages in .venv
+        PYTHON_SITE_PACKAGES=$(find .venv/lib -type d -name "python3.*" -exec echo {}/site-packages \;)
+        export LD_LIBRARY_PATH="${PYTHON_SITE_PACKAGES}:$LD_LIBRARY_PATH"
 
     # Commented out because linter rules violations are not fixed yet
     # - name: Lint with ruff

--- a/.github/workflows/test-and-lint.yaml
+++ b/.github/workflows/test-and-lint.yaml
@@ -1,0 +1,42 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Lint and test
+
+on:
+  workflow_call:
+
+jobs:
+  lint-and-test:
+    name: Lint and test
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/swvanbuuren/qt-python-docker:nightly
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install the project
+      run: |
+        uv sync
+
+    # Commented out because linter rules violations are not fixed yet
+    # - name: Lint with ruff
+    #   run: |
+    #     uv run ruff check ${{ github.event.repository.name }}
+
+    - name: Test with pytest
+      run: |
+        uv run pytest -v -s

--- a/.github/workflows/test-and-lint.yaml
+++ b/.github/workflows/test-and-lint.yaml
@@ -20,10 +20,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set environment variables
-      run: |
-        echo "UV_SYSTEM_PYTHON=true" >> $GITHUB_ENV
-
     # used docker image already has uv    
     # - name: Install uv
     #   uses: astral-sh/setup-uv@v3
@@ -36,6 +32,7 @@ jobs:
     - name: Install the project
       run: |
         uv sync
+        echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
 
     # Commented out because linter rules violations are not fixed yet
     # - name: Lint with ruff

--- a/.github/workflows/test-and-lint.yaml
+++ b/.github/workflows/test-and-lint.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     env:
         DISPLAY: ':99.0'
         QT_SELECT: "qt6"

--- a/.github/workflows/test-and-lint.yaml
+++ b/.github/workflows/test-and-lint.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Lint and test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/swvanbuuren/qt-python-docker:nightly
+      image: ghcr.io/swvanbuuren/qt-python-docker:master
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-and-lint.yaml
+++ b/.github/workflows/test-and-lint.yaml
@@ -10,19 +10,19 @@ jobs:
   lint-and-test:
     name: Lint and test
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/swvanbuuren/qt-python-docker:master
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    env:
+        DISPLAY: ':99.0'
+        QT_SELECT: "qt6"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # used docker image already has uv    
-    # - name: Install uv
-    #   uses: astral-sh/setup-uv@v3
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -32,12 +32,18 @@ jobs:
     - name: Install the project
       run: |
         uv sync
-        echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
 
     # Commented out because linter rules violations are not fixed yet
     # - name: Lint with ruff
     #   run: |
     #     uv run ruff check ${{ github.event.repository.name }}
+
+    - name: Install test dependencies
+      run: |
+        sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
+        sudo apt-get install -y '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+        # start xvfb in the background
+        sudo /usr/bin/Xvfb $DISPLAY -screen 0 1920x1080x24 &
 
     - name: Test with pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pyqtgraph",
     "pqthreads==0.4.1",
     "pyopengl",
+    "numpy>1.24.4"
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pyqtgraph",
     "pqthreads==0.4.1",
     "pyopengl",
-    "numpy>1.24.4"
+    "distutils"
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
@@ -26,8 +25,7 @@ urls = { Homepage = "https://github.com/swvanbuuren/mlpyqtgraph" }
 dependencies = [
     "pyqtgraph",
     "pqthreads==0.4.1",
-    "pyopengl",
-    "distutils"
+    "pyopengl"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Support for python v3.12 has been dropped (for the time being), since there's a dependency issues with the required numpy version of python v3.12 and missing `distutils` package (removed from the standard library as of v3.12).

Running in pre-built docker container not feasible.